### PR TITLE
Added "Delete Selected" button logic

### DIFF
--- a/webserver/templates/index.html
+++ b/webserver/templates/index.html
@@ -7,9 +7,12 @@
 {% block content %}
 <h1 class="text-3xl font-bold text-center mb-8">Available Recordings</h1>
 
-<div class="flex justify-end items-center mb-6">
+<div class="flex justify-end items-center mb-6 space-x-4">
   <button id="download-selected" class="bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-md px-4 py-2 flex items-center shadow-sm transition-colors duration-200">
     <i class="fas fa-download mr-2"></i>Download Selected
+  </button>
+  <button id="delete-selected" class="bg-red-500 hover:bg-red-600 text-white font-medium rounded-md px-4 py-2 flex items-center shadow-sm transition-colors duration-200">
+    <i class="fas fa-trash-alt mr-2"></i>Delete Selected
   </button>
 </div>
 


### PR DESCRIPTION
I added a "Delete Selected" button on my deployment because it helped a lot when I was testing & my Recordings tab got flooded with entries. It might also help people that want to do a cleanup of the entries after download, but don't want to click the Delete button for each entry or connect to the RPI.

This is how it looks:
<img width="1916" height="354" alt="Screenshot 2025-08-01 181130" src="https://github.com/user-attachments/assets/81ed275c-74c9-4d37-a205-e6869d75240d" />

I tested it a couple of times and it removed my selected entries correctly each time.
It also asks if you are sure you want to do this, so you don't press it by mistake, since it's close to the Download button.

Please feel free to test it further & make any adjustments you'd like to the code.
If you don't want this feature at all, feel free to close the PR. Thought I might share it anyway.