### PR TITLE
docs: set up the test env from uv.lock with hash verification

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -18,17 +18,31 @@ This project uses [uv](https://github.com/astral-sh/uv) by @astral-sh for a fast
 # Install uv if you don't have it
 pip install uv
 
-# Create and activate a virtual environment
-uv venv
+# Create the environment from the lockfile and install the project.
+# `--frozen` installs the EXACT versions pinned in uv.lock with NO re-resolution,
+# and uv verifies every downloaded artifact against the hash recorded in the
+# lock. So local dev and the manual test harness (test/test_server.py) run
+# against a reproducible, tamper-evident set of dependencies — a compromised
+# index serving a different "flask 3.0.3" would fail the hash check.
+uv sync --frozen
+
+# Activate it (or skip activation and use `uv run <cmd>`)
 source .venv/bin/activate            # Windows: .venv\Scripts\activate
-
-# Install dependencies
-uv pip install -e .                  # or: uv pip install -r requirements.txt
 ```
 
-If you change dependencies in `pyproject.toml`, regenerate `requirements.txt`:
+> Use `uv sync --frozen`, not `uv pip install -e .`, to set up the test
+> environment. `uv pip install` is the pip-compatible interface: it resolves
+> fresh from the `>=` specifiers in `pyproject.toml`, ignores `uv.lock`, and does
+> not enforce hashes — so it can pull newer (or substituted) versions than the
+> project is pinned to. After intentionally changing dependencies, run `uv lock`
+> to refresh `uv.lock` (and `uv pip compile pyproject.toml -o requirements.txt`
+> to refresh the pip mirror), then commit the updated lock.
+
+If you change dependencies in `pyproject.toml`, refresh both the lockfile and
+the `requirements.txt` pip mirror:
 
 ```
+uv lock                                          # update uv.lock
 uv pip compile pyproject.toml -o requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
Makes the documented local/test environment reproducible and tamper-evident by building it from `uv.lock` instead of resolving fresh.

## Problem
The setup docs used `uv pip install -e .`. That is uv's pip-compatible interface: it resolves fresh from the `>=` specifiers in `pyproject.toml`, **ignores `uv.lock`**, and does not enforce artifact hashes. The manual test harness (`test/test_server.py`) could therefore run against newer — or substituted — dependency versions than the project is pinned to.

## Change
- `docs/development.md` and the CLAUDE.md "Common commands" now use **`uv sync --frozen`**, which installs the exact versions pinned in `uv.lock` with no re-resolution and verifies every downloaded artifact against the lock's recorded hash (252 hashes). A compromised index serving a different "flask 3.0.3" fails the hash check rather than landing in the env.
- Document refreshing `uv.lock` (`uv lock`) alongside `requirements.txt` when dependencies change.

(Only `docs/development.md` is tracked; CLAUDE.md is gitignored/local.)

## Verification
`uv sync --frozen --dry-run` resolves cleanly against the current lock (no changes applied to the existing venv). It confirms the locked set is internally consistent and would pin the env back to the committed versions — it also surfaces `ruamel-yaml-clib==0.2.8`, which the `uv pip install` path had silently skipped.

## Security posture for testing
- **Prevention:** safe-chain blocks known-malware at install time.
- **Integrity / reproducibility:** `--frozen` + `uv.lock` hashes block tampered/substituted artifacts and version drift.

Container-based blast-radius isolation was considered and deferred — easy to revisit later.