### PR TITLE
Add title ui config option

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,3 +39,7 @@ time_exceeded_volume: 1.0
 recordings_path: __INSTALL_DIR__/recordings
 shutdown_gpio: 0 #Set GPIO pin here --> Note: Pin is active LOW, pull Pin to GND to activate shutdown
 shutdown_button_hold_time: 2 # default 2 seconds
+
+# UI Customizations
+ui:
+  title: Audio Guestbook # Page title displayed in browser and header

--- a/webserver/server.py
+++ b/webserver/server.py
@@ -96,6 +96,14 @@ def normalize_path(path):
     return str(path.as_posix())
 
 
+@app.context_processor
+def inject_title():
+    """Inject the UI title into all templates."""
+    current_config = load_config()
+    ui_config = current_config.get('ui') or {}
+    return {'title': ui_config.get('title', 'Audio Guestbook')}
+
+
 @app.route("/")
 def index():
     return render_template("index.html")
@@ -183,13 +191,7 @@ def edit_config():
             flash(f"Error updating configuration: {str(e)}", "error")
             # Continue with current configuration but show error
 
-    # Load the current configuration
-    try:
-        with config_path.open("r") as f:
-            current_config = yaml.load(f)
-    except FileNotFoundError as e:
-        logger.error(f"Configuration file not found: {e}")
-        current_config = {}
+    current_config = load_config()
 
     return render_template("config.html", config=current_config)
 
@@ -365,6 +367,15 @@ def shutdown():
             {"success": False, "message": "Failed to shut down the system!"}
         ), 500
 
+
+def load_config():
+    # Load the current configuration
+    try:
+        with config_path.open("r") as f:
+            return yaml.load(f)
+    except FileNotFoundError as e:
+        logger.error(f"Configuration file not found: {e}")
+        return {}
 
 def update_config(form_data):
     """Update the YAML configuration with form data."""

--- a/webserver/server.py
+++ b/webserver/server.py
@@ -192,8 +192,9 @@ def edit_config():
             # Continue with current configuration but show error
 
     current_config = load_config()
+    current_ui_config = current_config.get('ui') or {}
 
-    return render_template("config.html", config=current_config)
+    return render_template("config.html", config=current_config, ui_config=current_ui_config)
 
 
 @app.route("/recordings/<filename>")
@@ -382,6 +383,15 @@ def update_config(form_data):
     for key, value in form_data.items():
         # Skip CSRF token if it exists
         if key == 'csrf_token':
+            continue
+
+        # Handle nested config fields with underscore notation (ui_title -> ui.title)
+        if key.startswith('ui_'):
+            nested_key = key[3:]
+            if 'ui' not in config:
+                config['ui'] = {}
+            config['ui'][nested_key] = value
+            logger.info(f"Updated 'ui.{nested_key}' to: {value}")
             continue
 
         # Check if key exists in config

--- a/webserver/templates/base.html
+++ b/webserver/templates/base.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
   <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
   <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='img/favicon.ico') }}" />
-  <title>{% block title %}Audio Guestbook{% endblock %}</title>
+  <title>{% block title %}{{ title }}{% endblock %}</title>
   <link href="{{ url_for('static', filename='css/output.min.css') }}" rel="stylesheet" />
   <!-- Load theme.js first to ensure it initializes before page content -->
   <script src="{{ url_for('static', filename='js/theme.js') }}" defer></script>
@@ -22,7 +22,7 @@
         <!-- Left Side: Title with vintage phone icon -->
         <a href="{{ url_for('index') }}" class="text-2xl font-bold flex items-center">
           <i class="fas fa-phone-alt mr-2 transform -rotate-45"></i>
-          Audio Guestbook
+          {{ title }}
         </a>
 
         <!-- Right Side: Icons with labels on larger screens -->

--- a/webserver/templates/config.html
+++ b/webserver/templates/config.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %} {% block title %}Audio Guestbook - Settings{% endblock
+{% extends "base.html" %} {% block title %}{{ title }} - Settings{% endblock
 %} {% block content %}
 
 <h1 class="text-3xl font-bold text-center mb-8">Edit Configuration</h1>

--- a/webserver/templates/config.html
+++ b/webserver/templates/config.html
@@ -271,6 +271,23 @@
     </div>
   </div>
 
+    <!-- UI Settings Card -->
+    <div class="card">
+      <div class="bg-primary dark:bg-dark-primary p-2 lg:p-4 rounded-t">
+        <h2 class="font-bold text-lg text-text dark:text-dark-text">
+          UI Settings
+        </h2>
+      </div>
+      <div class="bg-secondary dark:bg-dark-secondary text-text dark:text-dark-text shadow-md p-4 rounded-b">
+        <div class="mb-2 lg:mb-4">
+          <label for="ui_title" class="block mb-1 lg:mb-2">Page Title</label>
+          <input type="text" id="ui_title" name="ui_title" value="{{ ui_config.get('title', 'Audio Guestbook') }}"
+            class="w-full px-3 py-2 border rounded bg-background dark:bg-dark-input-background text-text-primary dark:text-dark-input-text" />
+          <span class="text-xs text-gray-500 dark:text-gray-400 mt-1">Title displayed in browser and header</span>
+        </div>
+      </div>
+    </div>
+
   <!-- Floating Save Button -->
   <div class="bg-primary dark:bg-dark-primary fixed bottom-4 right-4 rounded-full">
     <button type="submit" class="btn-primary p-3 shadow-lg rounded-full">

--- a/webserver/templates/index.html
+++ b/webserver/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Audio Guestbook - Recordings{% endblock %}
+{% block title %}{{ title }} - Recordings{% endblock %}
 {% block extra_head %}
 <script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/hammer.min.js') }}"></script>


### PR DESCRIPTION
Adds a new config option to allow title customization:
```yaml
# UI Customizations
ui:
  title: Audio Guestbook # Page title displayed in browser and header
```

Displays on page titles and in the header component for all pages:

<img width="538" height="144" alt="image" src="https://github.com/user-attachments/assets/f566cf9f-d213-402d-a379-8e999f13a442" />

Default behavior is unchanged - if unset, title defaults to "Audio Guestbook"

---

Adds a new settings card to edit the ui.title entry
<img width="1392" height="422" alt="image" src="https://github.com/user-attachments/assets/72acb71e-5518-42bc-a9a5-a7f3b1497f0a" />

