### PR TITLE
Use `-` instead of `:` in file names

### DIFF
--- a/src/audioGuestBook.py
+++ b/src/audioGuestBook.py
@@ -107,7 +107,7 @@ def play_wav_interruptible(file_path, pin_hook, hw_mapping, volume, mixer_contro
 
 def start_recording(config):
     """Start arecord process for guest recording."""
-    timestamp = datetime.now().isoformat()
+    timestamp = datetime.now().isoformat().replace(':','-')
     recordings_path = Path(config['recordings_path'])
     recordings_path.mkdir(exist_ok=True)
     

--- a/webserver/static/js/recordings.js
+++ b/webserver/static/js/recordings.js
@@ -164,8 +164,12 @@ function createRecordingItem(filename) {
   row.className =
     "recording-item border-b border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200";
 
+  const formats = [
+    "YYYY-MM-DDTHH-mm-ss",
+    "YYYY-MM-DDTHH:mm:ss"
+  ];
   const dateTime = parseDateTime(filename);
-  const formattedDate = moment(dateTime).format("MMMM D, YYYY [at] h:mm A");
+  const formattedDate = moment(dateTime, formats).format("MMMM D, YYYY [at] h:mm A");
 
   // Generate a random pastel color for the recording icon
   const hue = Math.floor(Math.random() * 360);
@@ -197,7 +201,7 @@ function createRecordingItem(filename) {
 }
 
 function parseDateTime(filename) {
-  const regex = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})/;
+  const regex = /(\d{4}-\d{2}-\d{2}T\d{2}[:-]\d{2}[:-]\d{2})/;
   const match = filename.match(regex);
   return match ? match[1] : null;
 }


### PR DESCRIPTION
On some filesystems (fat32), `:` is an invalid filename character.

This PR saves files in the format `2026-10-24T20-13-14.841619.wav` and updates the frontend parsing to accept either format.
